### PR TITLE
selected options on orders now persists

### DIFF
--- a/client/src/Components/Menu/Accordions.tsx
+++ b/client/src/Components/Menu/Accordions.tsx
@@ -23,10 +23,10 @@ export const Accordion = withStyles({
 export const AccordionBtn = withStyles({
   root: {
     backgroundColor: "rgba(0, 0, 0, .07)",
-    // border: "1px solid rgba(0, 0, 0, .125)",
-    minHeight: 30,
+    border: "1px solid rgba(0, 0, 0, .125)",
+    minHeight: 46,
     "&$expanded": {
-      minHeight: 5,
+      minHeight: 12,
     },
   },
   content: {
@@ -40,5 +40,6 @@ export const AccordionBtn = withStyles({
 export const AccordionContent = withStyles((theme) => ({
   root: {
     padding: 5,
+    minHeight: 30,
   },
 }))(MuiAccordionDetails);

--- a/client/src/Components/Menu/Menu.css
+++ b/client/src/Components/Menu/Menu.css
@@ -40,3 +40,12 @@
   background-color: transparent;
   outline: none;
 }
+
+.item-price {
+  display: flex;
+  align-items: flex-end;
+}
+
+/* .MuiAccordionSummary-root {
+  justify-content: space-between;
+} */

--- a/client/src/Components/Menu/Menu.tsx
+++ b/client/src/Components/Menu/Menu.tsx
@@ -54,11 +54,10 @@ export default function Menu(props: any) {
     let _cartItems: CartItemType[] | undefined =
       cartItems.data?.cart[0]?.orderItems;
     let cartItemsList: OrderItemType[] = [];
-    _cartItems?.forEach((cartItem) => {
+    _cartItems?.forEach((cartItem: CartItemType) => {
       let itemInfo = context?.itemsList?.find((item) => {
         return item._id === cartItem.itemId;
       });
-      console.log("TYPE", Array.isArray(cartItem.seatId));
       let item: OrderItemType = {
         itemId: itemInfo?._id || "",
         name: itemInfo?.name || "",
@@ -66,8 +65,17 @@ export default function Menu(props: any) {
         presetOptionId: itemInfo?.presetOptionId || [],
         seatId: cartItem.seatId.map((seat) => seat),
         cartItemId: cartItem.uniqueItemId,
+        options: cartItem?.options?.map((option) => {
+          let selectedOption = itemInfo?.options?.find(
+            (itemOption) => itemOption._id === option.optionId
+          );
+          return {
+            optionId: option.optionId,
+            price: selectedOption?.price,
+            name: selectedOption?.name,
+          };
+        }),
       };
-      console.log("ADDING ITEM", item);
       context?.setItems("ADD_ITEM", item);
     });
   }, [cartItems.loading, cartItems.data, itemsListQuery.data]);

--- a/client/src/Components/Menu/MenuSectionCatItem.tsx
+++ b/client/src/Components/Menu/MenuSectionCatItem.tsx
@@ -3,6 +3,9 @@ import "./Menu.css";
 import Option from "./MenuSectionCatItemOptions";
 import { OptionOrderType, ItemType } from "../../types";
 import { Accordion, AccordionBtn, AccordionContent } from "./Accordions";
+import AccordionActions from "@material-ui/core/AccordionActions";
+import Divider from "@material-ui/core/Divider";
+import Button from "@material-ui/core/Button";
 import { addToCart } from "../../utils/cartStorage";
 import { OrderContext } from "../../context/Order";
 import socket from "../../utils/socket.io.js";
@@ -167,6 +170,13 @@ export default function Item({
             })}
           </div>
         </AccordionContent>
+        <Divider />
+        <AccordionActions>
+          <Button size="small">Cancel</Button>
+          <Button size="small" color="primary">
+            Add
+          </Button>
+        </AccordionActions>
       </Accordion>
     </div>
   );

--- a/client/src/Components/Menu/MenuSectionCatItemOptions.tsx
+++ b/client/src/Components/Menu/MenuSectionCatItemOptions.tsx
@@ -9,6 +9,7 @@ export default function Option({
   editOption,
   removeOption,
   isSelected,
+  showPrice,
 }: OptionType) {
   const [selected, setSelected] = React.useState(isSelected || false);
 
@@ -28,7 +29,9 @@ export default function Option({
         }}
       />
       <h3 style={{ margin: 0, marginBottom: 0 }}>{name}</h3>
-      <h3 style={{ margin: 0, marginBottom: 0 }}>${price}</h3>
+      {showPrice ? (
+        <h3 style={{ margin: 0, marginBottom: 0 }}>${price}</h3>
+      ) : null}
     </div>
   );
 }

--- a/client/src/graphql/items.ts
+++ b/client/src/graphql/items.ts
@@ -7,6 +7,7 @@ export const GET_ITEMS = gql`
       name
       presetOptionId
       options {
+        _id
         name
         price
       }

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -54,7 +54,11 @@ export interface CartItemType {
   _id: string;
   itemId: string;
   seatId: number[];
-  options: string[];
+  options: CartOptionType[];
   splitBill: number;
   uniqueItemId?: string;
+}
+
+export interface CartOptionType {
+  optionId: string;
 }

--- a/server/db.js
+++ b/server/db.js
@@ -94,12 +94,36 @@ const items = [
     categoryId: 3,
   },
   {
+    id: 99,
+    name: "Classic BLT",
+    price: 1250,
+    presetOptionId: [39, 8, 7, 19],
+    validOptionId: [39, 8, 7, 19, 38, 13],
+    categoryId: 4,
+  },
+  {
     id: 1,
     name: "Classic Burger",
     price: 1250,
     presetOptionId: [7, 8, 9, 10, 11, 12],
     validOptionId: [7, 8, 9, 10, 11, 12],
     categoryId: 4,
+  },
+  {
+    id: 2,
+    name: "Margherita Pizza",
+    price: 2200,
+    presetOptionId: [1, 7],
+    validOptionId: [1, 2, 3, 4, 5, 6, 7],
+    categoryId: 5,
+  },
+  {
+    id: 2,
+    name: "Pepperoni Pizza",
+    price: 2200,
+    presetOptionId: [1, 2, 7],
+    validOptionId: [1, 2, 3, 4, 5, 6],
+    categoryId: 5,
   },
   {
     id: 2,
@@ -111,7 +135,7 @@ const items = [
   },
   {
     id: 3,
-    name: "Fish Tacos",
+    name: "Surf Tacos",
     price: 1500,
     presetOptionId: [23],
     validOptionId: [23, 24, 25],
@@ -119,10 +143,10 @@ const items = [
   },
   {
     id: 3,
-    name: "Fish Tacos",
+    name: "Turf Tacos",
     price: 1500,
-    presetOptionId: [23],
-    validOptionId: [23, 24, 25],
+    presetOptionId: [38],
+    validOptionId: [38, 40, 41],
     categoryId: 6,
   },
   {
@@ -185,8 +209,8 @@ const items = [
     id: 8,
     name: "Tea",
     price: 100,
-    presetOptionId: [26, 27, 28],
-    validOptionId: [26],
+    presetOptionId: [26],
+    validOptionId: [26, 27, 28],
     categoryId: 10,
   },
   {
@@ -242,7 +266,7 @@ exports.items = items;
 
 const options = [
   { id: 1, name: "Mozzarella", price: 100 },
-  { id: 2, name: "Pepperonni", price: 100 },
+  { id: 2, name: "Pepperoni", price: 100 },
   { id: 3, name: "Pineapple", price: 100 },
   { id: 4, name: "Green Peppers", price: 100 },
   { id: 5, name: "Mushrooms", price: 100 },
@@ -280,6 +304,8 @@ const options = [
   { id: 37, name: "Shiraz", price: 0 },
   { id: 38, name: "Chicken", price: 300 },
   { id: 39, name: "Bacon", price: 300 },
+  { id: 40, name: "Beef", price: 300 },
+  { id: 41, name: "Pulled Pork", price: 300 },
 ];
 exports.options = options;
 


### PR DESCRIPTION
When placing a customized order the details were not displayed on reload. This is now fixed